### PR TITLE
Unit test generated files are now cleaned up

### DIFF
--- a/code_generator.py
+++ b/code_generator.py
@@ -133,6 +133,7 @@ class CodeFile:
         '''
         self.current_indent = 0
         self.last = None
+        self.filename = filename
         self.out = open(filename, "w")
  
     def close(self):

--- a/cpp_generator_tests.py
+++ b/cpp_generator_tests.py
@@ -209,7 +209,6 @@ def generate_enum():
         enum_elements_custom.add_item(item)
     enum_elements_custom.render_to_string(cpp)
     cpp.close()
-    os.remove(cpp.filename)
 
 
 def generate_var():
@@ -240,7 +239,6 @@ def generate_var():
         var.render_to_string(cpp)
 
     cpp.close()
-    os.remove(cpp.filename)
 
 
 def generate_array():
@@ -263,7 +261,6 @@ def generate_array():
         arr.render_to_string(cpp)
 
     cpp.close()
-    os.remove(cpp.filename)
 
 
 def generate_func():
@@ -287,9 +284,7 @@ def generate_func():
     for func in functions:
         func.render_to_string_implementation(cpp)
     cpp.close()
-    os.remove(cpp.filename)
     hpp.close()
-    os.remove(hpp.filename)
 
 
 def generate_class():
@@ -355,9 +350,7 @@ def generate_class():
     my_class.declaration().render_to_string(my_class_h)
     my_class.definition().render_to_string(my_class_cpp)
     my_class_cpp.close()
-    os.remove(cpp.filename)
     my_class_h.close()
-    os.remove(h.filename)
 
 
 def generate_reference_code():

--- a/cpp_generator_tests.py
+++ b/cpp_generator_tests.py
@@ -1,5 +1,6 @@
 import unittest
 import filecmp
+import os
 
 from code_generator import *
 from cpp_generator import *
@@ -47,6 +48,7 @@ class TestCppGenerator(unittest.TestCase):
             var.render_to_string(cpp)
         self.assertTrue(filecmp.cmpfiles('.', 'tests', 'var.cpp'))
         cpp.close()
+        os.remove(cpp.filename)
 
     def test_cpp_arrays(self):
         '''
@@ -71,6 +73,7 @@ class TestCppGenerator(unittest.TestCase):
             arr.render_to_string(cpp)
         self.assertTrue(filecmp.cmpfiles('.', 'tests', 'array.cpp'))
         cpp.close()
+        os.remove(cpp.filename)
 
     def test_cpp_function(self):
         '''
@@ -94,7 +97,9 @@ class TestCppGenerator(unittest.TestCase):
         self.assertTrue(filecmp.cmpfiles('.', 'tests', 'func.cpp'))
         self.assertTrue(filecmp.cmpfiles('.', 'tests', 'func.h'))
         cpp.close()
+        os.remove(cpp.filename)
         hpp.close()
+        os.remove(hpp.filename)
 
     def test_cpp_enum(self):
         '''
@@ -113,6 +118,7 @@ class TestCppGenerator(unittest.TestCase):
 
         self.assertTrue(filecmp.cmpfiles('.', 'tests', 'enum.cpp'))
         cpp.close()
+        os.remove(cpp.filename)
 
     def test_cpp_class(self):
         '''
@@ -179,7 +185,9 @@ class TestCppGenerator(unittest.TestCase):
         self.assertTrue(filecmp.cmpfiles('.', 'tests', 'class.cpp'))
         self.assertTrue(filecmp.cmpfiles('.', 'tests', 'class.h'))
         my_class_cpp.close()
+        os.remove(my_class_cpp.filename)
         my_class_h.close()
+        os.remove(my_class_h.filename)
 
 
 # Generate test data
@@ -199,6 +207,7 @@ def generate_enum():
         enum_elements_custom.add_item(item)
     enum_elements_custom.render_to_string(cpp)
     cpp.close()
+    os.remove(cpp.filename)
 
 
 def generate_var():
@@ -229,6 +238,7 @@ def generate_var():
         var.render_to_string(cpp)
 
     cpp.close()
+    os.remove(cpp.filename)
 
 
 def generate_array():
@@ -251,6 +261,7 @@ def generate_array():
         arr.render_to_string(cpp)
 
     cpp.close()
+    os.remove(cpp.filename)
 
 
 def generate_func():
@@ -274,7 +285,9 @@ def generate_func():
     for func in functions:
         func.render_to_string_implementation(cpp)
     cpp.close()
+    os.remove(cpp.filename)
     hpp.close()
+    os.remove(hpp.filename)
 
 
 def generate_class():
@@ -340,7 +353,9 @@ def generate_class():
     my_class.declaration().render_to_string(my_class_h)
     my_class.definition().render_to_string(my_class_cpp)
     my_class_cpp.close()
+    os.remove(cpp.filename)
     my_class_h.close()
+    os.remove(h.filename)
 
 
 def generate_reference_code():

--- a/cpp_generator_tests.py
+++ b/cpp_generator_tests.py
@@ -46,8 +46,9 @@ class TestCppGenerator(unittest.TestCase):
 
         for var in variables:
             var.render_to_string(cpp)
-        self.assertTrue(filecmp.cmpfiles('.', 'tests', 'var.cpp'))
         cpp.close()
+        expected_cpp = ['var.cpp']
+        self.assertEqual(filecmp.cmpfiles('.', 'tests', expected_cpp)[0], expected_cpp)
         os.remove(cpp.filename)
 
     def test_cpp_arrays(self):
@@ -71,8 +72,9 @@ class TestCppGenerator(unittest.TestCase):
 
         for arr in arrays:
             arr.render_to_string(cpp)
-        self.assertTrue(filecmp.cmpfiles('.', 'tests', 'array.cpp'))
         cpp.close()
+        expected_cpp = ['array.cpp']
+        self.assertEqual(filecmp.cmpfiles('.', 'tests', expected_cpp)[0], expected_cpp)
         os.remove(cpp.filename)
 
     def test_cpp_function(self):
@@ -94,11 +96,13 @@ class TestCppGenerator(unittest.TestCase):
             func.render_to_string_declaration(hpp)
         for func in functions:
             func.render_to_string_implementation(cpp)
-        self.assertTrue(filecmp.cmpfiles('.', 'tests', 'func.cpp'))
-        self.assertTrue(filecmp.cmpfiles('.', 'tests', 'func.h'))
+        expected_cpp = ['func.cpp']
+        expected_h = ['func.h']
         cpp.close()
-        os.remove(cpp.filename)
         hpp.close()
+        self.assertEqual(filecmp.cmpfiles('.', 'tests', expected_cpp)[0], expected_cpp)
+        self.assertEqual(filecmp.cmpfiles('.', 'tests', expected_h)[0], expected_h)
+        os.remove(cpp.filename)
         os.remove(hpp.filename)
 
     def test_cpp_enum(self):
@@ -116,8 +120,9 @@ class TestCppGenerator(unittest.TestCase):
             enum_elements_custom.add_item(item)
         enum_elements_custom.render_to_string(cpp)
 
-        self.assertTrue(filecmp.cmpfiles('.', 'tests', 'enum.cpp'))
         cpp.close()
+        expected_cpp = ['enum.cpp']
+        self.assertEqual(filecmp.cmpfiles('.', 'tests', expected_cpp)[0], expected_cpp)
         os.remove(cpp.filename)
 
     def test_cpp_class(self):
@@ -182,11 +187,13 @@ class TestCppGenerator(unittest.TestCase):
         my_class.declaration().render_to_string(my_class_h)
         my_class.definition().render_to_string(my_class_cpp)
 
-        self.assertTrue(filecmp.cmpfiles('.', 'tests', 'class.cpp'))
-        self.assertTrue(filecmp.cmpfiles('.', 'tests', 'class.h'))
         my_class_cpp.close()
-        os.remove(my_class_cpp.filename)
         my_class_h.close()
+        expected_cpp = ['class.cpp']
+        expected_h = ['class.h']
+        self.assertEqual(filecmp.cmpfiles('.', 'tests', expected_cpp)[0], expected_cpp)
+        self.assertEqual(filecmp.cmpfiles('.', 'tests', expected_h)[0], expected_h)
+        os.remove(my_class_cpp.filename)
         os.remove(my_class_h.filename)
 
 

--- a/cpp_generator_tests.py
+++ b/cpp_generator_tests.py
@@ -37,11 +37,6 @@ class TestCppGenerator(unittest.TestCase):
                                  type="std::string",
                                  is_class_member=False,
                                  is_static=False,
-                                 is_const=False),
-                     CppVariable(name="var3",
-                                 type="std::string",
-                                 is_class_member=False,
-                                 is_static=False,
                                  is_const=False)]
 
         for var in variables:


### PR DESCRIPTION
Self explanatory. I figured I'd break this update into its own PR. I'm not sure if the intention was to keep the generated files around when running unit tests. If so, then I can easily add support for conditionally removing the generated files.

I am planning on adding some support for additional features:

- documentation (e.g. doxygen, javadoc, etc)
- constructors

I'm sure more will come to mind as I proceed. If you would prefer me to not create PRs in the future, just let me know. I will try to break them up into isolated PRs so it's easier to review.