### PR TITLE
Added documentation property support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,138 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/README.md
+++ b/README.md
@@ -111,4 +111,22 @@ cpp.append(', p = NULL);')
 ```
 cpp.newline(2)
 ```
+
+## Maintainers
+
+### Executing unit tests
+The following command will execute the unit tests.
+
+```
+python -m unittest cpp_generator_tests.py
+```
+
+### Updating unit tests fixed data
+After changing a unit test the fixed data needs to be updated to successfully pass the unit tests.
+
+```
+python -c 'cpp_generator_tests import generate_reference_code; generate_reference_code()'
+```
+
+After executing that command, the fixed data under `tests/` will be updated and will need to be committed to git.
  

--- a/README.md
+++ b/README.md
@@ -21,20 +21,19 @@ However, this solution has been both simplified and extended compared to the ini
 #### 1 Creating variables
 
 ##### 1.1 Python code
-```
-
+```python
 cpp = CodeFile('example.cpp')
 cpp('int i = 0;')
 ```
 
 ##### 1.2 Generated C++ code
-```
+```c++
 int i = 0;
 ```
 #### 2 Creating classes and structures
 
 ##### 2.1 Python code
-```
+```python
 cpp = CppFile('example.cpp')
 with cpp.block('class A', ';'):
     cpp.label('public:')
@@ -43,7 +42,7 @@ with cpp.block('class A', ';'):
 ```
 
 ##### 2.2 Generated C++ code
-```
+```c++
 class A
 {
 public:
@@ -56,7 +55,8 @@ public:
 
 ##### 3.1 Python code
 
-```cpp_class = CppClass(name = 'MyClass', is_struct = True)
+```python
+cpp_class = CppClass(name = 'MyClass', is_struct = True)
 cpp_class.add_variable(CppVariable(name = "m_var",
     type = 'size_t',
     is_static = True,
@@ -66,14 +66,15 @@ cpp_class.add_variable(CppVariable(name = "m_var",
  
 ##### 3.2 Generated C++ declaration
 
-```struct MyClass
+```c++
+struct MyClass
 {
     static const size_t m_var;
 }
 ```
  
 #### 3.3 Generated C++ implementation
-```
+```c++
 const size_t MyClass::m_var = 255;
 ```
 
@@ -92,23 +93,23 @@ Class `ANSICodeStyle` is responsible for code formatting. Re-implement it if you
 It support:
 
 - functional calls:
-```
+```python
 cpp('int a = 10;')
 ```
  
 - `with` semantic:
-```
+```python
 with cpp.block('class MyClass', ';')
     class_definition(cpp)
 ```
  
 - append code to the last string without EOL:
-```
+```python
 cpp.append(', p = NULL);')
 ```
  
 - empty lines:
-```
+```python
 cpp.newline(2)
 ```
 
@@ -117,14 +118,14 @@ cpp.newline(2)
 ### Executing unit tests
 The following command will execute the unit tests.
 
-```
+```bash
 python -m unittest cpp_generator_tests.py
 ```
 
 ### Updating unit tests fixed data
 After changing a unit test the fixed data needs to be updated to successfully pass the unit tests.
 
-```
+```bash
 python -c 'cpp_generator_tests import generate_reference_code; generate_reference_code()'
 ```
 

--- a/cpp_generator_tests.py
+++ b/cpp_generator_tests.py
@@ -17,219 +17,49 @@ class TestCppGenerator(unittest.TestCase):
     '''
 
     def test_cpp_variables(self):
-        '''
-        Test C++ variables generation
-        '''
-        cpp = CppFile('var.cpp')
-        variables = [CppVariable(name="var1",
-                                 type="char*",
-                                 is_class_member=False,
-                                 is_static=False,
-                                 is_const=True,
-                                 initialization_value='0'),
-                     CppVariable(name="var2",
-                                 type="int",
-                                 is_class_member=False,
-                                 is_static=True,
-                                 is_const=False,
-                                 initialization_value='0'),
-                     CppVariable(name="var3",
-                                 type="std::string",
-                                 is_class_member=False,
-                                 is_static=False,
-                                 is_const=False),
-                     CppVariable(name="var4",
-                                 type="int",
-                                 documentation='// A number',
-                                 is_class_member=False,
-                                 is_static=False,
-                                 is_const=False),
-        ]
-
-        for var in variables:
-            var.render_to_string(cpp)
-        cpp.close()
+        generate_var(output_dir='.')
         expected_cpp = ['var.cpp']
         self.assertEqual(filecmp.cmpfiles('.', 'tests', expected_cpp)[0], expected_cpp)
-        os.remove(cpp.filename)
+        os.remove(expected_cpp[0])
 
     def test_cpp_arrays(self):
-        '''
-        Test C++ variables generation
-        '''
-        cpp = CppFile('array.cpp')
-        arrays = []
-        a1 = CppArray(name='array1', type='int', is_const=True, arraySize=5)
-        a1.add_array_items(['1', '2', '3'])
-        a2 = CppArray(name='array2', type='const char*', is_const=True)
-        a2.add_array_item('"Item1"')
-        a2.add_array_item('"Item2"')
-        a3 = CppArray(name='array3', type='const char*', is_const=True, newline_align=True)
-        a3.add_array_item('"ItemNewline1"')
-        a3.add_array_item('"ItemNewline2"')
-
-        arrays.append(a1)
-        arrays.append(a2)
-        arrays.append(a3)
-
-        for arr in arrays:
-            arr.render_to_string(cpp)
-        cpp.close()
+        generate_array(output_dir='.')
         expected_cpp = ['array.cpp']
         self.assertEqual(filecmp.cmpfiles('.', 'tests', expected_cpp)[0], expected_cpp)
-        os.remove(cpp.filename)
+        os.remove(expected_cpp[0])
 
     def test_cpp_function(self):
-        '''
-        Test C++ functions generation
-        '''
-        cpp = CppFile('func.cpp')
-        hpp = CppFile('func.h')
-
-        def function_body(_, cpp1):
-            cpp1('return 42;')
-
-        functions = [CppFunction(name='GetParam', ret_type='int'),
-                     CppFunction(name='Calculate', ret_type='void'),
-                     CppFunction(name='GetAnswer', ret_type='int', implementation_handle=function_body),
-                     CppFunction(name='Help', ret_type='char *', documentation='/// Returns the help documentation.'),
-        ]
-        for func in functions:
-            func.render_to_string(hpp)
-        for func in functions:
-            func.render_to_string_declaration(hpp)
-        for func in functions:
-            func.render_to_string_implementation(cpp)
+        generate_func(output_dir='.')
         expected_cpp = ['func.cpp']
         expected_h = ['func.h']
-        cpp.close()
-        hpp.close()
         self.assertEqual(filecmp.cmpfiles('.', 'tests', expected_cpp)[0], expected_cpp)
         self.assertEqual(filecmp.cmpfiles('.', 'tests', expected_h)[0], expected_h)
-        os.remove(cpp.filename)
-        os.remove(hpp.filename)
+        os.remove(expected_cpp[0])
+        os.remove(expected_h[0])
 
     def test_cpp_enum(self):
-        '''
-        Test C++ enums generation
-        '''
-        cpp = CppFile('enum.cpp')
-        enum_elements = CppEnum(name='Items')
-        for item in ['Chair', 'Table', 'Shelve']:
-            enum_elements.add_item(item)
-        enum_elements.render_to_string(cpp)
-
-        enum_elements_custom = CppEnum(name='Items', prefix='it')
-        for item in ['Chair', 'Table', 'Shelve']:
-            enum_elements_custom.add_item(item)
-        enum_elements_custom.render_to_string(cpp)
-
-        cpp.close()
+        generate_enum(output_dir='.')
         expected_cpp = ['enum.cpp']
         self.assertEqual(filecmp.cmpfiles('.', 'tests', expected_cpp)[0], expected_cpp)
-        os.remove(cpp.filename)
+        os.remove(expected_cpp[0])
 
     def test_cpp_class(self):
-        '''
-        Test C++ classes generation
-        '''
-        my_class_cpp = CppFile('class.cpp')
-        my_class_h = CppFile('class.h')
-        my_class = CppClass(name='MyClass')
-        example_class = CppClass(
-            name='Example',
-            documentation='''\
-                /// An example
-                /// class with
-                /// multiline documentation''',
-        )
-
-        enum_elements = CppEnum(name='Items', prefix='wd')
-        for item in ['One', 'Two', 'Three']:
-            enum_elements.add_item(item)
-        my_class.add_enum(enum_elements)
-
-        nested_class = CppClass(name='Nested', is_struct=True)
-        nested_class.add_variable(CppVariable(name="m_gcAnswer",
-                                              type="size_t",
-                                              is_class_member=True,
-                                              is_static=True,
-                                              is_const=True,
-                                              initialization_value='42'))
-        my_class.add_internal_class(nested_class)
-
-        my_class.add_variable(CppVariable(name="m_var1",
-                                          type="int",
-                                          initialization_value='1'))
-
-        my_class.add_variable(CppVariable(name="m_var2",
-                                          type="int*"))
-
-        example_class.add_variable(CppVariable(
-            name="m_var1",
-            documentation="/// A number.",
-            type="int"),
-        )
-
-        a2 = CppArray(name='array2', type='char*', is_const=True, is_static=True, )
-        a2.add_array_item('"Item1"')
-        a2.add_array_item('"Item2"')
-        a3 = CppArray(name='array3', type='char*', is_static=True, is_const=True, newline_align=True)
-        a3.add_array_item('"ItemNewline1"')
-        a3.add_array_item('"ItemNewline2"')
-
-        my_class.add_array(a2)
-        my_class.add_array(a3)
-
-        def method_body(_, cpp):
-            cpp('return m_var1;')
-
-        example_class.add_method(CppFunction(name="DoNothing",
-                                             documentation="""\
-                                                 /**
-                                                  * Example multiline documentation.
-                                                  */""",
-                                             ret_type="void"))
-
-        my_class.add_method(CppFunction(name="GetParam",
-                                        ret_type="int",
-                                        is_method=True,
-                                        is_const=True,
-                                        implementation_handle=method_body))
-
-        my_class.add_method(CppFunction(name="VirtualMethod",
-                                        ret_type="int",
-                                        is_method=True,
-                                        is_virtual=True))
-
-        my_class.add_method(CppFunction(name="PureVirtualMethod",
-                                        ret_type="void",
-                                        is_method=True,
-                                        is_virtual=True,
-                                        is_pure_virtual=True))
-
-        my_class.declaration().render_to_string(my_class_h)
-        example_class.declaration().render_to_string(my_class_h)
-        my_class.definition().render_to_string(my_class_cpp)
-        example_class.definition().render_to_string(my_class_cpp)
-
-        my_class_cpp.close()
-        my_class_h.close()
+        generate_class(output_dir='.')
         expected_cpp = ['class.cpp']
         expected_h = ['class.h']
         self.assertEqual(filecmp.cmpfiles('.', 'tests', expected_cpp)[0], expected_cpp)
         self.assertEqual(filecmp.cmpfiles('.', 'tests', expected_h)[0], expected_h)
-        os.remove(my_class_cpp.filename)
-        os.remove(my_class_h.filename)
+        os.remove(expected_cpp[0])
+        os.remove(expected_h[0])
 
 
 # Generate test data
-def generate_enum():
+def generate_enum(output_dir='.'):
     '''
     Generate model data (C++ enum)
     Do not call unless generator logic is changed
     '''
-    cpp = CppFile('tests/enum.cpp')
+    cpp = CppFile(os.path.join(output_dir, 'enum.cpp'))
     enum_elements = CppEnum(name='Items')
     for item in ['Chair', 'Table', 'Shelve']:
         enum_elements.add_item(item)
@@ -242,12 +72,12 @@ def generate_enum():
     cpp.close()
 
 
-def generate_var():
+def generate_var(output_dir='.'):
     '''
     Generate model data (C++ variables)
     Do not call unless generator logic is changed
     '''
-    cpp = CppFile('tests/var.cpp')
+    cpp = CppFile(os.path.join(output_dir, 'var.cpp'))
     variables = [CppVariable(name="var1",
                              type="char*",
                              is_class_member=False,
@@ -279,8 +109,8 @@ def generate_var():
     cpp.close()
 
 
-def generate_array():
-    cpp = CppFile('tests/array.cpp')
+def generate_array(output_dir='.'):
+    cpp = CppFile(os.path.join(output_dir, 'array.cpp'))
     arrays = []
     a1 = CppArray(name='array1', type='int', is_const=True, arraySize=5)
     a1.add_array_items(['1', '2', '3'])
@@ -301,13 +131,13 @@ def generate_array():
     cpp.close()
 
 
-def generate_func():
+def generate_func(output_dir='.'):
     '''
     Generate model data (C++ functions)
     Do not call unless generator logic is changed
     '''
-    cpp = CppFile('tests/func.cpp')
-    hpp = CppFile('tests/func.h')
+    cpp = CppFile(os.path.join(output_dir, 'func.cpp'))
+    hpp = CppFile(os.path.join(output_dir, 'func.h'))
 
     def function_body(_, cpp1):
         cpp1('return 42;')
@@ -327,13 +157,13 @@ def generate_func():
     hpp.close()
 
 
-def generate_class():
+def generate_class(output_dir='.'):
     '''
     Generate model data (C++ classes)
     Do not call unless generator logic is changed
     '''
-    my_class_cpp = CppFile('tests/class.cpp')
-    my_class_h = CppFile('tests/class.h')
+    my_class_cpp = CppFile(os.path.join(output_dir, 'class.cpp'))
+    my_class_h = CppFile(os.path.join(output_dir, 'class.h'))
     my_class = CppClass(name='MyClass', ref_to_parent=None)
     example_class = CppClass(
         name='Example',
@@ -422,11 +252,11 @@ def generate_reference_code():
     Generate model data for C++ generator
     Do not call unless generator logic is changed
     '''
-    generate_enum()
-    generate_var()
-    generate_array()
-    generate_func()
-    generate_class()
+    generate_enum(output_dir='tests')
+    generate_var(output_dir='tests')
+    generate_array(output_dir='tests')
+    generate_func(output_dir='tests')
+    generate_class(output_dir='tests')
 
 
 if __name__ == "__main__":

--- a/cpp_generator_tests.py
+++ b/cpp_generator_tests.py
@@ -37,7 +37,14 @@ class TestCppGenerator(unittest.TestCase):
                                  type="std::string",
                                  is_class_member=False,
                                  is_static=False,
-                                 is_const=False)]
+                                 is_const=False),
+                     CppVariable(name="var4",
+                                 type="int",
+                                 documentation='// A number',
+                                 is_class_member=False,
+                                 is_static=False,
+                                 is_const=False),
+        ]
 
         for var in variables:
             var.render_to_string(cpp)
@@ -84,7 +91,9 @@ class TestCppGenerator(unittest.TestCase):
 
         functions = [CppFunction(name='GetParam', ret_type='int'),
                      CppFunction(name='Calculate', ret_type='void'),
-                     CppFunction(name='GetAnswer', ret_type='int', implementation_handle=function_body)]
+                     CppFunction(name='GetAnswer', ret_type='int', implementation_handle=function_body),
+                     CppFunction(name='Help', ret_type='char *', documentation='/// Returns the help documentation.'),
+        ]
         for func in functions:
             func.render_to_string(hpp)
         for func in functions:
@@ -127,6 +136,13 @@ class TestCppGenerator(unittest.TestCase):
         my_class_cpp = CppFile('class.cpp')
         my_class_h = CppFile('class.h')
         my_class = CppClass(name='MyClass')
+        example_class = CppClass(
+            name='Example',
+            documentation='''\
+                /// An example
+                /// class with
+                /// multiline documentation''',
+        )
 
         enum_elements = CppEnum(name='Items', prefix='wd')
         for item in ['One', 'Two', 'Three']:
@@ -149,6 +165,12 @@ class TestCppGenerator(unittest.TestCase):
         my_class.add_variable(CppVariable(name="m_var2",
                                           type="int*"))
 
+        example_class.add_variable(CppVariable(
+            name="m_var1",
+            documentation="/// A number.",
+            type="int"),
+        )
+
         a2 = CppArray(name='array2', type='char*', is_const=True, is_static=True, )
         a2.add_array_item('"Item1"')
         a2.add_array_item('"Item2"')
@@ -161,6 +183,13 @@ class TestCppGenerator(unittest.TestCase):
 
         def method_body(_, cpp):
             cpp('return m_var1;')
+
+        example_class.add_method(CppFunction(name="DoNothing",
+                                             documentation="""\
+                                                 /**
+                                                  * Example multiline documentation.
+                                                  */""",
+                                             ret_type="void"))
 
         my_class.add_method(CppFunction(name="GetParam",
                                         ret_type="int",
@@ -180,7 +209,9 @@ class TestCppGenerator(unittest.TestCase):
                                         is_pure_virtual=True))
 
         my_class.declaration().render_to_string(my_class_h)
+        example_class.declaration().render_to_string(my_class_h)
         my_class.definition().render_to_string(my_class_cpp)
+        example_class.definition().render_to_string(my_class_cpp)
 
         my_class_cpp.close()
         my_class_h.close()
@@ -233,7 +264,14 @@ def generate_var():
                              type="std::string",
                              is_class_member=False,
                              is_static=False,
-                             is_const=False)]
+                             is_const=False),
+                 CppVariable(name="var4",
+                             type="int",
+                             documentation='// A number',
+                             is_class_member=False,
+                             is_static=False,
+                             is_const=False),
+    ]
 
     for var in variables:
         var.render_to_string(cpp)
@@ -276,7 +314,9 @@ def generate_func():
 
     functions = [CppFunction(name='GetParam', ret_type='int'),
                  CppFunction(name='Calculate', ret_type='void'),
-                 CppFunction(name='GetAnswer', ret_type='int', implementation_handle=function_body)]
+                 CppFunction(name='GetAnswer', ret_type='int', implementation_handle=function_body),
+                 CppFunction(name='Help', ret_type='char *', documentation='/// Returns the help documentation.'),
+    ]
     for func in functions:
         func.render_to_string(hpp)
     for func in functions:
@@ -295,6 +335,13 @@ def generate_class():
     my_class_cpp = CppFile('tests/class.cpp')
     my_class_h = CppFile('tests/class.h')
     my_class = CppClass(name='MyClass', ref_to_parent=None)
+    example_class = CppClass(
+        name='Example',
+        documentation='''\
+            /// An example
+            /// class with
+            /// multiline documentation''',
+    )
 
     enum_elements = CppEnum(name='Items', prefix='wd')
     for item in ['One', 'Two', 'Three']:
@@ -316,6 +363,12 @@ def generate_class():
 
     my_class.add_variable(CppVariable(name="m_var2",
                                       type="int*"))
+
+    example_class.add_variable(CppVariable(
+        name="m_var1",
+        documentation="/// A number.",
+        type="int"),
+    )
 
     a2 = CppArray(name='array2', type='char*', is_const=True, is_static=True, )
     a2.add_array_item('"Item1"')
@@ -347,8 +400,19 @@ def generate_class():
                                     is_virtual=True,
                                     is_pure_virtual=True))
 
+    example_class.add_method(CppFunction(
+        name="DoNothing",
+        documentation="""\
+            /**
+             * Example multiline documentation.
+             */""",
+        ret_type="void"),
+    )
+
     my_class.declaration().render_to_string(my_class_h)
+    example_class.declaration().render_to_string(my_class_h)
     my_class.definition().render_to_string(my_class_cpp)
+    example_class.definition().render_to_string(my_class_cpp)
     my_class_cpp.close()
     my_class_h.close()
 

--- a/tests/class.cpp
+++ b/tests/class.cpp
@@ -27,3 +27,12 @@ int MyClass::GetParam() const
 const size_t MyClass::Nested::m_gcAnswer  = 42;
 
 
+
+
+/**
+ * Example multiline documentation.
+ */
+void Example::DoNothing()
+{
+}
+

--- a/tests/class.h
+++ b/tests/class.h
@@ -33,3 +33,17 @@ private:
 	static const char* array3[];
 	
 };
+/// An example
+/// class with
+/// multiline documentation
+class Example 
+{
+public:
+	void DoNothing();
+	
+	
+private:
+	/// A number.
+	int m_var1;
+	
+};

--- a/tests/func.cpp
+++ b/tests/func.cpp
@@ -8,3 +8,7 @@ int GetAnswer()
 {
 	return 42;
 }
+/// Returns the help documentation.
+char * Help()
+{
+}

--- a/tests/func.h
+++ b/tests/func.h
@@ -8,6 +8,10 @@ int GetAnswer()
 {
 	return 42;
 }
+char * Help()
+{
+}
 int GetParam();
 void Calculate();
 int GetAnswer();
+char * Help();

--- a/tests/var.cpp
+++ b/tests/var.cpp
@@ -1,3 +1,5 @@
 const char* var1 = 0;
 static int var2 = 0;
 std::string var3;
+// A number
+int var4;


### PR DESCRIPTION
This PR adds support for a `documentation` property to the `CppClass`, `CppVariable`, and `CppFunction` classes. I added what I thought were some basic examples to the unit tests, but there may be use cases I did not think of.

Also included in this PR are changes I made to refactor `cpp_generator_tests.py` to eliminate the need to update multiple locations when adding or changing features. I created a Maintainers section in the README.md for some basic usage since it took me a little bit to figure out how to use it myself.