### PR TITLE
Refactored CodeFile and CppFile to accept a writer

### DIFF
--- a/code_generator.py
+++ b/code_generator.py
@@ -126,15 +126,19 @@ class CodeFile:
     # Current formatting style (assigned as a class attribute to generate all files uniformly)
     Formatter = ANSICodeStyle
  
-    def __init__(self, filename):
+    def __init__(self, filename, writer=None):
         '''
         Creates a new source file
         @param: filename source file to create (rewrite if exists)
+        @param: writer optional writer to write output to
         '''
         self.current_indent = 0
         self.last = None
         self.filename = filename
-        self.out = open(filename, "w")
+        if writer:
+            self.out = writer
+        else:
+            self.out = open(filename, "w")
  
     def close(self):
         '''
@@ -185,11 +189,11 @@ class CppFile(CodeFile):
     '''
     This class extends CodeFile class with some specific C++ constructions
     '''
-    def __init__(self, filename):
+    def __init__(self, filename, writer=None):
         '''
         Create C++ source file
         '''
-        CodeFile.__init__(self, filename)
+        CodeFile.__init__(self, filename, writer)
         
     def label(self, text):
         '''

--- a/cpp_generator_tests.py
+++ b/cpp_generator_tests.py
@@ -1,6 +1,7 @@
 import unittest
 import filecmp
 import os
+import io
 
 from code_generator import *
 from cpp_generator import *
@@ -15,6 +16,18 @@ class TestCppGenerator(unittest.TestCase):
     '''
     Test C++ code generation
     '''
+
+    def test_cpp_var_via_writer(self):
+        writer = io.StringIO()
+        cpp = CppFile(None, writer=writer)
+        variables = CppVariable(name="var1",
+                                type="char*",
+                                is_class_member=False,
+                                is_static=False,
+                                is_const=True,
+                                initialization_value='0')
+        variables.render_to_string(cpp)
+        self.assertEqual('const char* var1 = 0;\n', writer.getvalue())
 
     def test_cpp_variables(self):
         generate_var(output_dir='.')


### PR DESCRIPTION
This allows the caller to specify their own writer and not be forced to
writing to a file. This will also allow for faster unit tests since they
don't have to deal with file IO delays.

I chose to leave the API as is, so you can continue using it as it was originally
designed. It will only use the specified writer if the caller specifies it. This way
all the existing regression tests still pass, but now allows for new tests to be
added without the need to create and update the fixed files under the tests/
directory.