### PR TITLE
Added constexpr and extern support to CppVariable and constexpr support to CppFunction

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,15 @@ However, this solution has been both simplified and extended compared to the ini
 ```python
 cpp = CodeFile('example.cpp')
 cpp('int i = 0;')
+
+x_variable = CppVariable(name='x', type='int const&', is_static=True, is_constexpr=True, initialization_value='42')
+x_variable.render_to_string(cpp)
 ```
 
 ##### 1.2 Generated C++ code
 ```c++
 int i = 0;
+static constexpr int const& x = 42;
 ```
 #### 2 Creating classes and structures
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ However, this solution has been both simplified and extended compared to the ini
 
 ### Generate C++ code from Python code
 
-#### 1 Creating variables
+#### Creating variables
 
-##### 1.1 Python code
+##### Python code
 ```python
 cpp = CodeFile('example.cpp')
 cpp('int i = 0;')
@@ -29,15 +29,15 @@ x_variable = CppVariable(name='x', type='int const&', is_static=True, is_constex
 x_variable.render_to_string(cpp)
 ```
 
-##### 1.2 Generated C++ code
+##### Generated C++ code
 ```c++
 int i = 0;
 static constexpr int const& x = 42;
 ```
 
-#### 2. Creating functions
+#### Creating functions
 
-##### 2.1 Python code
+##### Python code
 ```python
 def handle_to_factorial(self, cpp):
     cpp('return n < 1 ? 1 : (n * factorial(n - 1));')
@@ -53,7 +53,7 @@ factorial_function.add_argument('int n')
 factorial_function.render_to_string(cpp)
 ```
 
-##### 2.2 Generated C++ code
+##### Generated C++ code
 ```c++
 /// Calculates and returns the factorial of \p n.
 constexpr int factorial(int n)
@@ -62,9 +62,9 @@ constexpr int factorial(int n)
 }
 ```
 
-#### 2 Creating classes and structures
+#### Creating classes and structures
 
-##### 2.1 Python code
+##### Python code
 ```python
 cpp = CppFile('example.cpp')
 with cpp.block('class A', ';'):
@@ -73,7 +73,7 @@ with cpp.block('class A', ';'):
     cpp('double m_classMember2;')
 ```
 
-##### 2.2 Generated C++ code
+##### Generated C++ code
 ```c++
 class A
 {
@@ -83,9 +83,9 @@ public:
 };
 ```
 
-#### 3 Rendering `CppClass` objects to C++ declaration and implementation
+#### Rendering `CppClass` objects to C++ declaration and implementation
 
-##### 3.1 Python code
+##### Python code
 
 ```python
 cpp_class = CppClass(name = 'MyClass', is_struct = True)
@@ -96,7 +96,7 @@ cpp_class.add_variable(CppVariable(name = "m_var",
     initialization_value = 255))
 ```
  
-##### 3.2 Generated C++ declaration
+##### Generated C++ declaration
 
 ```c++
 struct MyClass
@@ -105,7 +105,7 @@ struct MyClass
 }
 ```
  
-#### 3.3 Generated C++ implementation
+#### Generated C++ implementation
 ```c++
 const size_t MyClass::m_var = 255;
 ```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,34 @@ x_variable.render_to_string(cpp)
 int i = 0;
 static constexpr int const& x = 42;
 ```
+
+#### 2. Creating functions
+
+##### 2.1 Python code
+```python
+def handle_to_factorial(self, cpp):
+    cpp('return n < 1 ? 1 : (n * factorial(n - 1));')
+
+cpp = CodeFile('example.cpp')
+
+factorial_function = CppFunction(name='factorial',
+    ret_type='int',
+    is_constexpr=True,
+    implementation_handle=handle_to_factorial,
+    documentation='/// Calculates and returns the factorial of \p n.')
+factorial_function.add_argument('int n')
+factorial_function.render_to_string(cpp)
+```
+
+##### 2.2 Generated C++ code
+```c++
+/// Calculates and returns the factorial of \p n.
+constexpr int factorial(int n)
+{
+    return n <= 1 ? 1 : (n * factorial(n - 1));
+}
+```
+
 #### 2 Creating classes and structures
 
 ##### 2.1 Python code

--- a/README.md
+++ b/README.md
@@ -27,12 +27,16 @@ cpp('int i = 0;')
 
 x_variable = CppVariable(name='x', type='int const&', is_static=True, is_constexpr=True, initialization_value='42')
 x_variable.render_to_string(cpp)
+
+name_variable = CppVariable(name='name', type='char*', is_extern=True)
+name_variable.render_to_string(cpp)
 ```
 
 ##### Generated C++ code
 ```c++
 int i = 0;
 static constexpr int const& x = 42;
+extern char* name;
 ```
 
 #### Creating functions

--- a/cpp_generator.py
+++ b/cpp_generator.py
@@ -419,6 +419,7 @@ class CppVariable(CppLanguageElement):
     Available properties:
     type - string, variable type
     is_static - boolean, 'static' prefix
+    is_extern - boolean, 'extern' prefix
     is_const - boolean, 'const' prefix
     initialization_value - string, value to be initialized with. 
         'a = value;' for automatic variables, 'a(value)' for the class member
@@ -427,6 +428,7 @@ class CppVariable(CppLanguageElement):
     '''
     availablePropertiesNames = {'type',
                                 'is_static',
+                                'is_extern',
                                 'is_const',
                                 'is_constexpr',
                                 'initialization_value',
@@ -443,6 +445,8 @@ class CppVariable(CppLanguageElement):
             raise RuntimeError("Variable object can be either 'const' or 'constexpr', not both")
         if self.is_constexpr and not self.initialization_value:
             raise RuntimeError("Variable object must be initialized when 'constexpr'")
+        if self.is_static and self.is_extern:
+            raise RuntimeError("Variable object can be either 'extern' or 'static', not both")
 
     def declaration(self):
         '''
@@ -470,7 +474,7 @@ class CppVariable(CppLanguageElement):
         else:
             if self.documentation:
                 cpp(dedent(self.documentation))
-            cpp('{0}{1}{2} {3}{4};'.format('static ' if self.is_static else '',
+            cpp('{0}{1}{2} {3}{4};'.format('static ' if self.is_static else 'extern ' if self.is_extern else '',
                                            'const ' if self.is_const else 'constexpr ' if self.is_constexpr else '',
                                            self.type,
                                            self.name,

--- a/cpp_generator.py
+++ b/cpp_generator.py
@@ -271,6 +271,8 @@ class CppFunction(CppLanguageElement):
         '''
         # check all properties for the consistency
         self.__sanity_check()
+        if self.documentation and self.is_constexpr:
+            cpp(dedent(self.documentation))
         with cpp.block('{0}{1}{2} {3}({4}){5}{6}'.format(
             'virtual ' if self.is_virtual else '',
             'constexpr ' if self.is_constexpr else '',
@@ -291,6 +293,8 @@ class CppFunction(CppLanguageElement):
         # check all properties for the consistency
         self.__sanity_check()
         if self.is_constexpr:
+            if self.documentation:
+                cpp(dedent(self.documentation))
             with cpp.block('{0}constexpr {1} {2}({3}){4}{5}'.format(
                 'virtual ' if self.is_virtual else '',
                 self.ret_type if self.ret_type else '',
@@ -320,7 +324,7 @@ class CppFunction(CppLanguageElement):
         '''
         # check all properties for the consistency
         self.__sanity_check()
-        if self.documentation:
+        if self.documentation and not self.is_constexpr:
             cpp(dedent(self.documentation))
         with cpp.block('{0}{1} {2}{3}({4}){5}{6}'.format(
                 '/*virtual*/' if self.is_virtual else '',

--- a/cpp_generator_tests.py
+++ b/cpp_generator_tests.py
@@ -29,6 +29,34 @@ class TestCppGenerator(unittest.TestCase):
         variables.render_to_string(cpp)
         self.assertEqual('const char* var1 = 0;\n', writer.getvalue())
 
+    def test_is_constexpr_raises_error_when_is_const_true(self):
+        self.assertRaises(RuntimeError, CppVariable, name="COUNT", type="int", is_class_member=True, is_const=True, is_constexpr=True, initialization_value='0')
+
+    def test_is_constexpr_raises_error_when_initialization_value_is_none(self):
+        self.assertRaises(RuntimeError, CppVariable, name="COUNT", type="int", is_class_member=True, is_constexpr=True)
+
+    def test_is_constexpr_render_to_string(self):
+        writer = io.StringIO()
+        cpp = CppFile(None, writer=writer)
+        variables = CppVariable(name="COUNT",
+                                type="int",
+                                is_class_member=False,
+                                is_constexpr=True,
+                                initialization_value='0')
+        variables.render_to_string(cpp)
+        self.assertIn('constexpr int COUNT = 0;', writer.getvalue())
+
+    def test_is_constexpr_render_to_string_declaration(self):
+        writer = io.StringIO()
+        cpp = CppFile(None, writer=writer)
+        variables = CppVariable(name="COUNT",
+                                type="int",
+                                is_class_member=True,
+                                is_constexpr=True,
+                                initialization_value='0')
+        variables.render_to_string_declaration(cpp)
+        self.assertIn('constexpr int COUNT = 0;', writer.getvalue())
+
     def test_cpp_variables(self):
         generate_var(output_dir='.')
         expected_cpp = ['var.cpp']

--- a/cpp_generator_tests.py
+++ b/cpp_generator_tests.py
@@ -3,6 +3,7 @@ import filecmp
 import os
 import io
 
+from textwrap import dedent
 from code_generator import *
 from cpp_generator import *
 
@@ -10,6 +11,42 @@ from cpp_generator import *
 __doc__ = '''
 Unit tests for C++ code generator
 '''
+
+class TestCppFunctionGenerator(unittest.TestCase):
+
+    def handle_to_factorial(self, cpp):
+        cpp('return n < 1 ? 1 : (n * factorial(n - 1));')
+
+    def test_is_constexpr_raises_error_when_implementation_value_is_none(self):
+        writer = io.StringIO()
+        cpp = CppFile(None, writer=writer)
+        func = CppFunction(name="factorial", ret_type="int", is_constexpr=True)
+        self.assertRaises(RuntimeError, func.render_to_string, cpp)
+
+    def test_is_constexpr_render_to_string(self):
+        writer = io.StringIO()
+        cpp = CppFile(None, writer=writer)
+        func = CppFunction(name="factorial", ret_type="int", implementation_handle=TestCppFunctionGenerator.handle_to_factorial, is_constexpr=True)
+        func.add_argument('int n')
+        func.render_to_string(cpp)
+        self.assertIn(dedent('''\
+            constexpr int factorial(int n)
+            {
+            \treturn n < 1 ? 1 : (n * factorial(n - 1));
+            }'''), writer.getvalue())
+
+    def test_is_constexpr_render_to_string_declaration(self):
+        writer = io.StringIO()
+        cpp = CppFile(None, writer=writer)
+        func = CppFunction(name="factorial", ret_type="int", implementation_handle=TestCppFunctionGenerator.handle_to_factorial, is_constexpr=True)
+        func.add_argument('int n')
+        func.render_to_string_declaration(cpp)
+        self.assertIn(dedent('''\
+            constexpr int factorial(int n)
+            {
+            \treturn n < 1 ? 1 : (n * factorial(n - 1));
+            }'''), writer.getvalue())
+
 
 class TestCppVariableGenerator(unittest.TestCase):
 

--- a/cpp_generator_tests.py
+++ b/cpp_generator_tests.py
@@ -106,6 +106,16 @@ class TestCppVariableGenerator(unittest.TestCase):
         variables.render_to_string_declaration(cpp)
         self.assertIn('constexpr int COUNT = 0;', writer.getvalue())
 
+    def test_is_extern_raises_error_when_is_static_is_true(self):
+        self.assertRaises(RuntimeError, CppVariable, name="var1", type="char*", is_static=True, is_extern=True)
+
+    def test_is_extern_render_to_string(self):
+        writer = io.StringIO()
+        cpp = CppFile(None, writer=writer)
+        v = CppVariable(name="var1", type="char*", is_extern=True)
+        v.render_to_string(cpp)
+        self.assertIn('extern char* var1;', writer.getvalue())
+
 
 class TestCppGenerator(unittest.TestCase):
     '''

--- a/cpp_generator_tests.py
+++ b/cpp_generator_tests.py
@@ -11,11 +11,7 @@ __doc__ = '''
 Unit tests for C++ code generator
 '''
 
-
-class TestCppGenerator(unittest.TestCase):
-    '''
-    Test C++ code generation
-    '''
+class TestCppVariableGenerator(unittest.TestCase):
 
     def test_cpp_var_via_writer(self):
         writer = io.StringIO()
@@ -56,6 +52,12 @@ class TestCppGenerator(unittest.TestCase):
                                 initialization_value='0')
         variables.render_to_string_declaration(cpp)
         self.assertIn('constexpr int COUNT = 0;', writer.getvalue())
+
+
+class TestCppGenerator(unittest.TestCase):
+    '''
+    Test C++ code generation
+    '''
 
     def test_cpp_variables(self):
         generate_var(output_dir='.')

--- a/cpp_generator_tests.py
+++ b/cpp_generator_tests.py
@@ -12,6 +12,9 @@ __doc__ = '''
 Unit tests for C++ code generator
 '''
 
+def handle_to_factorial(self, cpp):
+    cpp('return n < 1 ? 1 : (n * factorial(n - 1));')
+
 class TestCppFunctionGenerator(unittest.TestCase):
 
     def handle_to_factorial(self, cpp):
@@ -42,6 +45,19 @@ class TestCppFunctionGenerator(unittest.TestCase):
         func.add_argument('int n')
         func.render_to_string_declaration(cpp)
         self.assertIn(dedent('''\
+            constexpr int factorial(int n)
+            {
+            \treturn n < 1 ? 1 : (n * factorial(n - 1));
+            }'''), writer.getvalue())
+
+    def test_README_example(self):
+        writer = io.StringIO()
+        cpp = CppFile(None, writer=writer)
+        factorial_function = CppFunction(name='factorial', ret_type='int', is_constexpr=True, implementation_handle=handle_to_factorial, documentation='/// Calculates and returns the factorial of \p n.')
+        factorial_function.add_argument('int n')
+        factorial_function.render_to_string(cpp)
+        self.assertIn(dedent('''\
+            /// Calculates and returns the factorial of \p n.
             constexpr int factorial(int n)
             {
             \treturn n < 1 ? 1 : (n * factorial(n - 1));


### PR DESCRIPTION
I have added more unit tests isolating the changes made to CppVariable and CppFunction classes. Also, I added more examples to the README.md showing the use of the `is_extern` and `is_constexpr` properties and their rendered output.

I hope you don't mind that I removed the manual numbering of headings in the README.md sections. I felt like it just required more maintenance than there should be when adding new sections or reordering them. Most markdown renderers will either automatically add the numbering I think, but if you want me to re-add them I can.